### PR TITLE
Add Date header

### DIFF
--- a/pgMail.sql
+++ b/pgMail.sql
@@ -34,6 +34,7 @@ puts $mySock "RCPT TO: $toemailaddress"
 gets $mySock name
 puts $mySock "DATA"
 gets $mySock name
+puts $mySock "Date: [clock format [clock seconds] -format {%a, %d %b %Y %H:%M:%S +0000} -gmt true]"
 puts $mySock "From: $mailfrom"
 puts $mySock "To: $mailto"
 puts $mySock "Subject: $mailsubject"


### PR DESCRIPTION
Because of problems with some clients that cannot handle emails without Date header. 
Android gives the data 1970-01-01 to mail without Date.

Maybe the smtp server should have added the Date header but it didn't so this patch solved it for me.