### PR TITLE
Main fix is adding UTF-8 encoding support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,12 @@
 Change Log.
 
+v1.5 - pgMail has been updated to support the utf-8 character set
+       inside pltclu. (thanks Glukhov Sergey)
+     - Updated README to reflect modern PostgreSQL implementations
+       as some commands and suggestions were actually deprecated. (me)
+     - Updated the example scripts to use modern trigger return
+       vs opaque data type. (me)
+
 v1.4 - pgMail now supports both HTML messaging and MULTIPART MIME
        messaging. It's backwards compatible. If you want to ONLY send
        HTML, you need to pass an empty string as your 4th argument.

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-pgMail v1.4 (11/16/2017)  
+pgMail v1.5 (12/10/2024)  
 pgMail is maintained by Branden R. Williams <brw@brandolabs.com> 
 
 Homepage: http://www.brandolabs.com/pgmail
@@ -6,7 +6,7 @@ Homepage: http://www.brandolabs.com/pgmail
 If you are interested in contributing to the project please email 
 the maintainer directly.
 ------------------------------------------------------------------
-Copyright 2002-2017 Branden R. Williams.
+Copyright 2002-2025 Branden R. Williams.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ which takes 4 arguments of type 'text' (Who is it from, who is it
 to, subject, and body of message), contacts the email server via 
 TCL sockets, and transmits your email (Now UTF-8 Compatible!).  
 
-Before you can use pgMail, you must install the TCL/u procedural
+Before you can use pgMail, you must enable the TCL/u procedural
 language.  TCL/u is an UNRESTRICTED version of TCL that the
 database may use in its stored functions.  ** Take into account
 that you must prepare adequate security precautions when adding 
@@ -38,13 +38,13 @@ to do bad things.
 
 To install the TCL/u procedural language, you must have compiled
 and installed the TCL extensions of PostgreSQL (or in the binary
-versions, just make sure you install the TCL RPM).  Once you 
+versions, just make sure you install the pltcl packages).  Once you 
 are sure this has been completed, simply type the following at
 the unix shell prompt as a database administrator.
 
-# createlang pltclu <database>
+# psql -c 'CREATE EXTENSION pltclu' <DATABASE>
 
-In the place of <database>, put the name of your database that 
+In the place of <DATABASE>, put the name of your database that 
 you will be adding the stored procedure to.  If you want it to
 also be added to all new databases, use "template1" as your 
 database name.
@@ -84,14 +84,14 @@ select pgmail('Send From <from@from.com>','Send To <to@to.com>',
 In both the Send From and Send To fields, you may include either
 only the email, or the email enclosed in <> with a plaintext name.
 
+The code in this repository is certified against PostgreSQL 15+.
+
 ------------------------------------------------------------------
 Testing your install.
 
 There are some examples to try which have been included.  You 
 MUST FIRST replace the string <YOUREMAIL> in the 
-example.execute.sql script with your real email address, and
-install the plpgsql language just like you did the pltclu above.
-You can do that by entering a "createlang [YOUR DATABASE] plpgsql".  
+example.execute.sql script with your real email address.
 
 Once that is complete, execute the example.setup.sql.  Then
 execute the example.execute.sql script.  You will see 2 emails 

--- a/example.setup.sql
+++ b/example.setup.sql
@@ -6,7 +6,7 @@ create table orders (
 	paystatus varchar(1) default 'n'
 );
 
-create function checkordermail() returns opaque as '
+create function checkordermail() returns trigger as '
 DECLARE
 	customerRec RECORD;
 	textMessage text;

--- a/pgMail.sql
+++ b/pgMail.sql
@@ -31,7 +31,7 @@ if {$fromemailaddress_start != -1} {
 	set fromemailaddress $mailfrom
 }
 fileevent $mySock writable [list svcHandler $mySock]
-fconfigure $mySock -buffering line
+fconfigure $mySock -buffering line -encoding utf-8
 puts $mySock "HELO <ENTER YOUR DATABASESERVER HERE>"
 gets $mySock name
 puts $mySock "MAIL FROM: $fromemailaddress"


### PR DESCRIPTION
Few updates in this PR.

* pgMail has been updated to support the utf-8 character set inside pltclu. (#13)
* Updated README to reflect modern PostgreSQL implementations as some commands and suggestions were actually deprecated.
* Updated the example scripts to use modern trigger return vs. opaque data type.
* Update version to 1.5.